### PR TITLE
First pass on figuring out how we will demux a signal to many apps

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+rubocop:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  NewCops: enable
+
+  Exclude:
+    - 'db/**/*'
+    - 'vendor/bundle/**/*'
+    - 'test/dummy/db/**/*'
+    - 'config/**/*'
+    - 'test/dummy/config/**/*'
+    - 'script/**/*'
+    - 'bin/{rails,rake}'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,13 +49,18 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     builder (3.2.4)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     erubi (1.9.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
@@ -75,6 +80,7 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    public_suffix (4.0.5)
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -103,6 +109,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (13.0.1)
+    safe_yaml (1.0.5)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -114,6 +121,10 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -125,6 +136,7 @@ DEPENDENCIES
   demux!
   pg
   rails (~> 5.1)
+  webmock
 
 BUNDLED WITH
    2.0.2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ $ gem install demux
 ```
 
 ## Contributing
-Contribution directions go here.
+After cloning repo:
+
+- install gems `bundle install`
+- set up the databases `bundle exec rake db:setup`
+- If you run into trouble setting up databases because of a missing postgres role, you can create one by running `psql` and then running `ALTER ROLE postgres LOGIN CREATEDB;`
+- If you cannot start `psql` because you are missing a database named after your local user, you can create one using `createdb`
+- You should not be able to run the tests `bundle exec rake`
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/models/demux/app.rb
+++ b/app/models/demux/app.rb
@@ -1,9 +1,55 @@
+# frozen_string_literal: true
+
 require "jwt"
 
 module Demux
+  # Demux::App represents an external app that can be connected to an account
+  # in the parent application.
   class App < ApplicationRecord
+    URL_REGEX = %r{\A(http(s?)\://.+)?\z}i.freeze
+
     has_many :connections
+    has_many :transmissions
     has_secure_token :secret
+
+    validates :entry_url, :signal_url, format: { with: URL_REGEX }
+
+    validates :name, presence: true
+
+    class << self
+      def listening_for(signal_name:, account_id:)
+        connections = Demux::Connection.listening_for(
+          signal_name: signal_name,
+          account_id: account_id
+        )
+
+        joins(:connections)
+          .merge(connections)
+          .where.not(signal_url: nil)
+      end
+
+      def without_queued_transmissions_for(signal_hash)
+        joins(
+          <<~SQL
+          LEFT OUTER JOIN demux_transmissions
+          ON demux_transmissions.app_id = demux_apps.id
+          AND demux_transmissions.status = 0
+          AND demux_transmissions.uniqueness_hash = '#{signal_hash}'
+          SQL
+        )
+          .where(demux_transmissions: { id: nil })
+      end
+
+      def transmission_requested_all(signal_attributes)
+        without_queued_transmissions_for(signal_attributes.hashed).each do |app|
+          app.transmission_requested(signal_attributes)
+        end
+      end
+    end
+
+    def transmission_requested(signal_attributes)
+      transmissions.queue(signal_attributes)
+    end
 
     # Return an entry url with JWT payload for authorization
     #
@@ -13,7 +59,8 @@ module Demux
     # @return [String] the entry url with signed token appended
 
     def signed_entry_url(data: {}, exp: 1.minute.from_now.to_i)
-      "#{entry_url}?token=#{JWT.encode({ data: data, exp: exp }, secret, 'HS256')}"
+      token = JWT.encode({ data: data, exp: exp }, secret, "HS256")
+      "#{entry_url}?token=#{token}"
     end
   end
 end

--- a/app/models/demux/connection.rb
+++ b/app/models/demux/connection.rb
@@ -1,6 +1,26 @@
+# frozen_string_literal: true
+
 module Demux
   class Connection < ApplicationRecord
     belongs_to :app
+
+    class << self
+      def listening_for(signal_name:, account_id:)
+        where(account_id: account_id)
+          .signal(signal_name)
+          .or(wildcard_signal)
+      end
+
+      def signal(signal)
+        where("demux_connections.signals @> ?", "{#{signal}}")
+      end
+
+      private
+
+      def wildcard_signal
+        where("demux_connections.signals @> ?", "{*}")
+      end
+    end
 
     # Return an entry url for this specific connection
     #

--- a/app/models/demux/transmission.rb
+++ b/app/models/demux/transmission.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Demux
+  # Demux::Transmission represents a signal being sent to an app
+  class Transmission < ApplicationRecord
+    belongs_to :app
+
+    before_save :update_uniqueness_hash
+
+    enum status: %i[queued sending success failure]
+
+    class << self
+      def for_app(app_relation)
+        joins(:app).merge(app_relation)
+      end
+
+      def queue(signal_attributes)
+        create(signal_attributes.to_hash)
+      rescue ActiveRecord::RecordNotUnique
+        # Unique index by status/uniqueness_hash
+      end
+    end
+
+    def transmit
+      return self unless attributes_required_to_transmit_present?
+
+      update(
+        request_url: app.signal_url,
+        request_body: payload.to_json,
+        status: :sending
+      )
+
+      save_receipt(Transmitter.new(self).transmit.receipt)
+
+      self
+    end
+
+    def save_receipt(receipt)
+      update(
+        status: receipt.success? ? :success : :failure,
+        response_code: receipt.http_code,
+        response_body: receipt.response_body,
+        request_headers: receipt.request_headers
+      )
+    end
+
+    def signal_name
+      signal.signal_name
+    end
+
+    def signature
+      OpenSSL::HMAC.hexdigest("SHA256", app.secret, request_body)
+    end
+
+    private
+
+    def signal_url
+      app.signal_url
+    end
+
+    def payload
+      @payload ||= { action: action }.merge(signal.payload_for(action))
+    end
+
+    def signal
+      @signal ||= signal_class.constantize.new(
+        object_id, account_id: account_id
+      )
+    end
+
+    def update_uniqueness_hash
+      return unless attributes_required_to_transmit_present?
+
+      self.uniqueness_hash = SignalAttributes.from_object(self).hashed
+    end
+
+    def attributes_required_to_transmit_present?
+      account_id? && action? && object_id? && signal_class?
+    end
+  end
+end

--- a/db/migrate/20200423143645_create_demux_apps.rb
+++ b/db/migrate/20200423143645_create_demux_apps.rb
@@ -5,9 +5,12 @@ class CreateDemuxApps < ActiveRecord::Migration[5.1]
       t.text :description
       t.string :secret
       t.string :entry_url
+      t.string :signal_url
+      t.text :signals, array:true, default: []
 
       t.timestamps
     end
+    add_index :demux_apps, :signals, using: "gin"
     add_index :demux_apps, :secret, unique: true
   end
 end

--- a/db/migrate/20200423144102_create_demux_connections.rb
+++ b/db/migrate/20200423144102_create_demux_connections.rb
@@ -3,9 +3,11 @@ class CreateDemuxConnections < ActiveRecord::Migration[5.1]
     create_table :demux_connections do |t|
       t.integer :account_id
       t.integer :app_id
+      t.text :signals, array:true, default: []
 
       t.timestamps
     end
+    add_index :demux_connections, :signals, using: "gin"
     add_index :demux_connections, :account_id
     add_index :demux_connections, :app_id
   end

--- a/db/migrate/20200505201706_create_demux_transmissions.rb
+++ b/db/migrate/20200505201706_create_demux_transmissions.rb
@@ -1,0 +1,23 @@
+class CreateDemuxTransmissions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :demux_transmissions do |t|
+      t.string :signal_class
+      t.string :action
+      t.integer :object_id
+      t.integer :app_id
+      t.integer :account_id
+      t.integer :status, default: 0
+      t.string :response_code
+      t.jsonb :response_headers
+      t.text :response_body
+      t.jsonb :request_headers
+      t.text :request_body
+      t.string :request_url
+      t.string :uniqueness_hash
+
+      t.timestamps
+    end
+    add_index :demux_transmissions, :app_id
+    add_index :demux_transmissions, [:uniqueness_hash, :app_id], unique: true, where: "status = 0"
+  end
+end

--- a/demux.gemspec
+++ b/demux.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "< 7", ">= 5.1"
   spec.add_dependency "jwt", ">= 1.5", "< 3"
+  spec.add_dependency "rails", "< 7", ">= 5.1"
 
   spec.add_development_dependency "pg"
+  spec.add_development_dependency "webmock"
 end

--- a/lib/demux.rb
+++ b/lib/demux.rb
@@ -1,5 +1,49 @@
-require "demux/engine"
+# frozen_string_literal: true
 
+require "demux/engine"
+require "demux/demuxer"
+require "demux/signal"
+require "demux/signal_attributes"
+require "demux/transmitter"
+
+# Demux toplevel namespace
 module Demux
-  # Your code goes here...
+  # Access the current configuration
+
+  module_function
+
+  def configuration
+    @configuration ||= Configuration.new
+  end
+
+  # Alias so that we can refer to configuration as config
+
+  def config
+    configuration
+  end
+
+  # Configure the library
+  #
+  # @yieldparam [Demux::Configuration] current_configuration
+  #
+  # @example
+  #   Demux.configure do |config|
+  #     config.default_demuxer = "Demux::Demuxer"
+  #   end
+  #
+  # @yieldreturn [Demux::Configuration]
+
+  def configure
+    yield configuration
+  end
+
+  # Configuration holds the current configuration for the SeisimicAPI
+  # and provides defaults
+  class Configuration
+    attr_accessor :default_demuxer
+
+    def initialize(args = {})
+      @default_demuxer = args.fetch(:default_demuxer) { Demux::Demuxer }
+    end
+  end
 end

--- a/lib/demux/demuxer.rb
+++ b/lib/demux/demuxer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Demux
+  # Demux::Demuxer is the heart of pairing signals to apps.
+  # It's a base implementation of what needs to happen, but apps can
+  # provide their own custom demuxer that calls out to this one.
+  #
+  # For example a host application will likely want to process signals in a
+  # background queue and can supply their own demuxer with details on how that
+  # should happen.
+  class Demuxer
+    def initialize(signal_attributes)
+      @signal_attributes = signal_attributes
+      @account_id = @signal_attributes.account_id
+      @signal_class = @signal_attributes.signal_class
+    end
+
+    def send_to_apps
+      queue_transmissions
+
+      queued_transmissions.each(&:transmit)
+
+      self
+    end
+
+    def queued_transmissions
+      Transmission
+        .queued
+        .for_app(listening_apps)
+        .where(uniqueness_hash: @signal_attributes.hashed)
+    end
+
+    def listening_apps
+      Demux::App.listening_for(
+        signal_name: @signal_class.constantize.signal_name,
+        account_id: @account_id
+      )
+    end
+
+    def queue_transmissions
+      listening_apps.transmission_requested_all(@signal_attributes)
+
+      self
+    end
+  end
+end

--- a/lib/demux/signal.rb
+++ b/lib/demux/signal.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Demux
+  # All signals will inherit from Demux::Signal. A signal represent a message
+  # to be demuxed and sent to apps.
+  class Signal
+    attr_reader :account_id
+
+    class << self
+      attr_reader :object_class, :signal_name
+
+      def attributes(attr)
+        @object_class = attr.fetch(:object_class)
+        @signal_name = attr.fetch(:signal_name)
+      end
+    end
+
+    def signal_name
+      self.class.signal_name
+    end
+
+    def initialize(object_id,
+                   account_id:,
+                   demuxer: Demux.config.default_demuxer)
+      @object_id = Integer(object_id)
+      @account_id = account_id
+      @demuxer = demuxer
+    end
+
+    def object
+      @object ||= self.class.object_class.find(@object_id)
+    end
+
+    def payload_for(action)
+      if respond_to?("#{action}_payload")
+        public_send("#{action}_payload")
+      else
+        payload
+      end
+    end
+
+    def send(action)
+      @demuxer.new(
+        SignalAttributes.new(
+          account_id: @account_id,
+          action: String(action),
+          object_id: @object_id,
+          signal_class: self.class.name
+        )
+      ).send_to_apps
+
+      self
+    end
+  end
+end

--- a/lib/demux/signal_attributes.rb
+++ b/lib/demux/signal_attributes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Demux
+  # Attributes that are commonly used to identify a signal
+  class SignalAttributes
+    attr_reader :account_id, :action, :object_id, :signal_class
+
+    class << self
+      def from_object(object)
+        new(
+          account_id: object.account_id,
+          action: object.action,
+          object_id: object.object_id,
+          signal_class: object.signal_class
+        )
+      end
+    end
+
+    def initialize(account_id:, action:, object_id:, signal_class:)
+      @account_id = account_id
+      @action = action
+      @object_id = object_id
+      @signal_class = String(signal_class)
+    end
+
+    def to_hash
+      {
+        account_id: @account_id,
+        action: @action,
+        object_id: @object_id,
+        signal_class: @signal_class
+      }
+    end
+
+    def hashed
+      Base64.strict_encode64({
+        account_id: account_id,
+        action: action,
+        object_id: object_id,
+        signal_class: signal_class
+      }.to_json)
+    end
+  end
+end

--- a/lib/demux/transmitter.rb
+++ b/lib/demux/transmitter.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module Demux
+  # Transmit a Transmission
+  class Transmitter
+    attr_reader :receipt
+    # Constructor
+    #
+    # @param transmission [Demux::Transmission] the transmission to be sent
+    #
+    # @return [self] the initialized Demux::Transmitter
+
+    def initialize(transmission)
+      @transmission = transmission
+      @uri = URI(@transmission.request_url)
+      @receipt = NullTransmissionReceipt.new
+    end
+
+    # Use the transmitter to send it's transmission
+    #
+    # @return [self]
+
+    def transmit
+      build_request
+
+      send_request
+
+      @receipt = TransmissionReceipt.new(@request, @response)
+
+      log_transmission
+
+      self
+    end
+
+    private
+
+    def build_request
+      @request = Net::HTTP::Post.new(@uri).tap do |request|
+        request["X-Demux-Signal"] = @transmission.signal_name
+        request["X-Demux-Signature"] = @transmission.signature
+        request["Content-Type"] = "application/json"
+        request["User-Agent"] = "Demux"
+        request.body = @transmission.request_body
+      end
+    end
+
+    def send_request
+      @response =
+        Net::HTTP.start(@uri.hostname, @uri.port, use_ssl: true) do |http|
+          http.request(@request)
+        end
+    end
+
+    def log_transmission
+      Rails.logger.debug(
+        "Send #{@transmission.signal_name}/#{@transmission.action} signal \
+            to #{@uri} \
+            with payload #{@transmission.request_body}"
+      )
+    end
+  end
+
+  # Null object to represent having no receipt
+  class NullTransmissionReceipt
+    def success?
+      nil
+    end
+
+    def http_code
+      nil
+    end
+
+    def request_headers
+      {}
+    end
+
+    def request_body
+      ""
+    end
+
+    def response_body
+      ""
+    end
+  end
+
+  # Returned when the Transmitter transmits
+  # @see Demux::Transmitter
+  class TransmissionReceipt
+    def initialize(request, response)
+      @raw_request = request
+      @raw_response = response
+    end
+
+    # Was the response code 2xx
+    #
+    # @return [Boolean]
+
+    def success?
+      @raw_response.is_a?(Net::HTTPSuccess)
+    end
+
+    # HTTP code of response
+    #
+    # @return [Integer] http code
+
+    def http_code
+      Integer(@raw_response.code)
+    end
+
+    # Headers that were sent with request
+    #
+    # @return [Hash] Hash of headers
+
+    def request_headers
+      @raw_request.each_header.to_h
+    end
+
+    # Body of the request
+    #
+    # @return [String] request body
+
+    def request_body
+      @raw_request.body
+    end
+
+    # Body of the response
+    #
+    # @return [String] response body
+
+    def response_body
+      @raw_response.body
+    end
+  end
+end

--- a/test/dummy/app/models/lesson.rb
+++ b/test/dummy/app/models/lesson.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Lesson < ApplicationRecord
+end

--- a/test/dummy/app/signals/lesson_signal.rb
+++ b/test/dummy/app/signals/lesson_signal.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class LessonSignal < Demux::Signal
+  attributes object_class: Lesson, signal_name: "lesson"
+
+  def payload
+    {
+      company_id: lesson.company_id,
+      lesson: {
+        id: @object_id,
+        name: lesson.name,
+        public: lesson.public
+      }
+    }
+  end
+
+  def updated
+    send :updated
+  end
+
+  def destroyed(context = {})
+    # How do we handle cases where we need to eager create the payload
+    # Do we just send the ID of the object in a case like this
+    # Some thoughts are below
+
+    # Just call the payload early and pass it into send
+    send :destroyed, payload: payload
+    # Indicate eager with boolean
+    send :destroyed, eager: true
+    # New method for sending in an eager way
+    send_now :destroyed
+    # Allow extra in the moment context to be added by the caller.
+    # We could have a base `destroyed_payload` method in here that is pretty
+    # sparse or empty and then the destroyer passes in context for the
+    # lesson that was destroyed.
+    # The concerning part here is that "what is sent" logic leaks out to the
+    # caller in this case and could be inconsistent.
+    send :destroyed, add_context: context
+  end
+
+  private
+
+  def lesson
+    object
+  end
+end

--- a/test/dummy/db/migrate/20200422135547_create_lessons.rb
+++ b/test/dummy/db/migrate/20200422135547_create_lessons.rb
@@ -1,0 +1,11 @@
+class CreateLessons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lessons do |t|
+      t.string :name
+      t.boolean :public
+      t.integer :company_id
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_144102) do
+ActiveRecord::Schema.define(version: 2020_05_05_201706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,18 +20,51 @@ ActiveRecord::Schema.define(version: 2020_04_23_144102) do
     t.text "description"
     t.string "secret"
     t.string "entry_url"
+    t.string "signal_url"
+    t.text "signals", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["secret"], name: "index_demux_apps_on_secret", unique: true
+    t.index ["signals"], name: "index_demux_apps_on_signals", using: :gin
   end
 
   create_table "demux_connections", force: :cascade do |t|
     t.integer "account_id"
     t.integer "app_id"
+    t.text "signals", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_demux_connections_on_account_id"
     t.index ["app_id"], name: "index_demux_connections_on_app_id"
+    t.index ["signals"], name: "index_demux_connections_on_signals", using: :gin
+  end
+
+  create_table "demux_transmissions", force: :cascade do |t|
+    t.string "signal_class"
+    t.string "action"
+    t.integer "object_id"
+    t.integer "app_id"
+    t.integer "account_id"
+    t.integer "status", default: 0
+    t.string "response_code"
+    t.jsonb "response_headers"
+    t.text "response_body"
+    t.jsonb "request_headers"
+    t.text "request_body"
+    t.string "request_url"
+    t.string "uniqueness_hash"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_demux_transmissions_on_app_id"
+    t.index ["uniqueness_hash", "app_id"], name: "index_demux_transmissions_on_uniqueness_hash_and_app_id", unique: true, where: "(status = 0)"
+  end
+
+  create_table "lessons", force: :cascade do |t|
+    t.string "name"
+    t.boolean "public"
+    t.integer "company_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/test/fixtures/demux/apps.yml
+++ b/test/fixtures/demux/apps.yml
@@ -1,13 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: First Cool App
-  description: An app to change your life
-  secret: secrettokenone
-  entry_url: http://oneapp.example.com/connection/new
+slack:
+  name: Slack
+  description: Sending slack messages from your application
+  secret: tokenslack
+  entry_url: http://slack.example.com/connection/new
+  signal_url: https://slack.example.com/hooks
 
-two:
-  name: MyString
-  description: MyText
-  secret: secrettokentwo
-  entry_url: MyString
+reporting:
+  name: Reporting Engine
+  description: Application for creating reports based on activity in your app
+  secret: tokenreporting
+  entry_url: http://reportz.biz/setup
+  signal_url: https://reportz.biz/webhooks

--- a/test/fixtures/demux/connections.yml
+++ b/test/fixtures/demux/connections.yml
@@ -1,9 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+acme_slack:
   account_id: 1
-  app: one
+  signals: ["lesson"]
+  app: slack
 
-two:
-  account_id: 2
-  app_id: two
+acme_reporting:
+  account_id: 1
+  signals: ["lesson"]
+  app: reporting

--- a/test/fixtures/lessons.yml
+++ b/test/fixtures/lessons.yml
@@ -1,0 +1,4 @@
+first_lesson:
+  name: First Lesson
+  public: false
+  company_id: 1

--- a/test/integration/demux/app_entry_test.rb
+++ b/test/integration/demux/app_entry_test.rb
@@ -1,12 +1,14 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module Demux
   class AppEntryTest < ActionDispatch::IntegrationTest
     test "a controller that redirects to an entry URL" do
-      connection = demux_connections(:one)
+      connection = demux_connections(:acme_slack)
 
       get "/configure_connection/#{connection.id}"
-      assert_redirected_to(/\/connection\/new\?token=/)
+      assert_redirected_to(%r{/connection/new\?token=})
     end
   end
 end

--- a/test/integration/demux/signals_test.rb
+++ b/test/integration/demux/signals_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Demux
+  class SignalsTest < ActionDispatch::IntegrationTest
+    test "sending a signal" do
+      lesson = lessons(:first_lesson)
+
+      slack_post = stub_request(:post, demux_apps(:slack).signal_url)
+      reporting_post = stub_request(:post, demux_apps(:reporting).signal_url)
+
+      LessonSignal.new(lesson.id, account_id: lesson.company_id).updated
+
+      assert_requested(slack_post)
+      assert_requested(reporting_post)
+    end
+  end
+end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/demux/app_test.rb
+++ b/test/models/demux/app_test.rb
@@ -1,16 +1,20 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module Demux
   class AppTest < ActiveSupport::TestCase
     test "#signed_entry_url returns an entry URL with a signed token" do
-      app = demux_apps(:one)
+      app = demux_apps(:slack)
 
       url = app.signed_entry_url(data: { account_id: 9 })
       token = url.match(/token=(?<token>.*)/)[:token]
-      decoded_token = JWT.decode(token, app.secret, true, { algorithm: 'HS256' })
+      decoded_token = JWT.decode(
+        token, app.secret, true, { algorithm: "HS256" }
+      )
 
       assert_equal(9, decoded_token.first["data"]["account_id"])
-      assert_match(/.*\/connection\/new\?token=.*/, url)
+      assert_match(%r{.*/connection/new\?token=.*}, url)
     end
   end
 end

--- a/test/models/demux/connection_test.rb
+++ b/test/models/demux/connection_test.rb
@@ -1,14 +1,18 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 module Demux
   class ConnectionTest < ActiveSupport::TestCase
     test "#entry_url requests a app entry url with account_id as payload" do
-      connection = demux_connections(:one)
-      app = demux_apps(:one)
+      connection = demux_connections(:acme_slack)
+      app = demux_apps(:slack)
 
       url = connection.entry_url
       token = url.match(/token=(?<token>.*)/)[:token]
-      decoded_token = JWT.decode(token, app.secret, true, { algorithm: 'HS256' })
+      decoded_token = JWT.decode(
+        token, app.secret, true, { algorithm: "HS256" }
+      )
 
       assert_equal(
         connection.account_id,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
-ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
+ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 require "rails/test_help"
+require "webmock/minitest"
 
 # Filter out the backtrace from minitest while preserving the one from other libraries.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
-
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)


### PR DESCRIPTION
# Overview

When a given events happens in lessonly and we notify Demux about it, at
that point Demux will need to find any apps that are installed on the
"account" the event happened in and send a webhook/ signal to any of
those apps that are listening for that event.

- Demux is notified something happened
- Demux finds apps installed on given account (company in our case)
- Demux finds which of these apps are listening for this event
- Demux will now send this webhook/signal out to the apps

Currently, the thought is that the means by which the signals are sent
would be determined by the "demuxer" you have configured. By default, it
would use a base "in memory" demuxer but in production we would likely
use a "sidekiq" based demuxer. It would call the base behavior but
inside of asynchronous jobs.

# Where it landed

I think we have a viable API here for defining and sending webhook "Signals". It would make adding and configuring a new signal super clear and allow grouping of signals under a name.

We have a basic inline demuxer. This would likely not be used in production, but the goal was to make it simple to override and add app specific behavior. In our case, we'll define a demuxer that splits out into sidekiq jobs.

You can now open a console and call the LessonSignal in the dummy app and see it work end to end 🎉 We also have one integration spec that tests it end to end by doing just that and mocking the http endpoints.

Since the API is starting to stabilize and this works in the end to end happy path, I'm going to stop here and merge before continuing.

# Things yet to consider in future work

- Test individual methods and look for edge cases
- Performance testing. It appears from sql explains that looking up by uniqueness hash is more performant that using a where across several fields; does that continue to hold up?
- What about signals that need to capture data in the moment? For example... when a record is destroyed we can't get it's "title" attribute later because it's gone. How can we pass in the moment context?
- Add missing inline documentation
- Add limits... 10 second request timeout for example
- Capture and record any headers from the response if they are given
- Make user agent and the names of demux specific headers configurable to something besides demux
- What if there is an internal exception when trying to send signal. Should we capture that status somehow on the transmission? The request didn't fail because the system failed before it was sent... but maybe we just want that to bubble up as it does now?
