### PR TITLE
Add a configurable timeout for sending signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming
 
-Nothing yet
+- [Make it easier to override the Demuxer](https://github.com/rreinhardt9/demux/pull/4/commits/970a0005125587368c837752820113a94b85292c)
+- [Add the ability to configure a timeout duration](https://github.com/rreinhardt9/demux/pull/9) for sending a signal and set it to 10 seconds by default
 
 # 0.1.0.beta / 5-29-2020
 

--- a/app/models/demux/transmission.rb
+++ b/app/models/demux/transmission.rb
@@ -7,7 +7,7 @@ module Demux
 
     before_save :update_uniqueness_hash
 
-    enum status: %i[queued sending success failure]
+    enum status: %i[queued sending success failure timeout]
 
     class << self
       def for_app(app_relation)
@@ -37,7 +37,7 @@ module Demux
 
     def save_receipt(receipt)
       update(
-        status: receipt.success? ? :success : :failure,
+        status: receipt.status,
         response_code: receipt.http_code,
         response_body: receipt.response_body,
         request_headers: receipt.request_headers

--- a/demux.gemspec
+++ b/demux.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "< 7", ">= 5.1"
 
   spec.add_development_dependency "pg"
+  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "webmock"
 end

--- a/lib/demux.rb
+++ b/lib/demux.rb
@@ -8,9 +8,11 @@ require "demux/transmitter"
 
 # Demux toplevel namespace
 module Demux
-  # Access the current configuration
-
   module_function
+
+  class Error < StandardError; end
+
+  # Access the current configuration
 
   def configuration
     @configuration ||= Configuration.new
@@ -40,10 +42,16 @@ module Demux
   # Configuration holds the current configuration for the SeisimicAPI
   # and provides defaults
   class Configuration
+    # return [#resolve] (Demux::Demuxer) object called to resolve a signal
+    #   to apps
     attr_accessor :default_demuxer
+
+    # @return [Integer] (10) time in seconds before transmitter will timeout
+    attr_accessor :signal_timeout
 
     def initialize(args = {})
       @default_demuxer = args.fetch(:default_demuxer) { Demux::Demuxer }
+      @signal_timeout = args.fetch(:signal_timeout, 10)
     end
   end
 end

--- a/test/integration/demux/signals_test.rb
+++ b/test/integration/demux/signals_test.rb
@@ -8,12 +8,69 @@ module Demux
       lesson = lessons(:first_lesson)
 
       slack_post = stub_request(:post, demux_apps(:slack).signal_url)
+        .with(
+          body: hash_including(
+            action: "updated",
+            company_id: 1,
+            lesson: {
+              id: lesson.id,
+              name: lesson.name,
+              public: lesson.public
+            }
+          ),
+          headers: {
+            "Content-Type" => "application/json",
+            "User-Agent" => "Demux",
+            "X-Demux-Signal" => "lesson",
+            "X-Demux-Signature" => /\w.+/
+          }
+        )
       reporting_post = stub_request(:post, demux_apps(:reporting).signal_url)
 
       LessonSignal.new(lesson.id, account_id: lesson.company_id).updated
 
       assert_requested(slack_post)
       assert_requested(reporting_post)
+    end
+
+    test "signal times out" do
+      lesson = lessons(:first_lesson)
+      slack = demux_apps(:slack)
+      reporting = demux_apps(:reporting)
+
+      slack_post = stub_request(:post, slack.signal_url)
+        .with(
+          body: hash_including(
+            action: "updated",
+            company_id: 1,
+            lesson: {
+              id: lesson.id,
+              name: lesson.name,
+              public: lesson.public
+            }
+          ),
+          headers: {
+            "Content-Type" => "application/json",
+            "User-Agent" => "Demux",
+            "X-Demux-Signal" => "lesson",
+            "X-Demux-Signature" => /\w.+/
+          }
+        )
+        .to_timeout # Net::OpenTimeout
+
+      reporting_post = stub_request(:post, reporting.signal_url)
+        .to_raise(Net::ReadTimeout)
+
+      LessonSignal.new(lesson.id, account_id: lesson.company_id).updated
+
+      assert_requested(slack_post)
+      assert_requested(reporting_post)
+
+      slack_transmission = slack.transmissions.last
+      assert_equal slack_transmission.status, "timeout"
+
+      reporting_transmission = reporting.transmissions.last
+      assert_equal reporting_transmission.status, "timeout"
     end
   end
 end


### PR DESCRIPTION
closes #7 

Tracked in this private "Clubhouse" card: https://app.clubhouse.io/lessonly/story/48800

Client apps should process signals sent to them in a timely fashion
because it consumes resources from the host application and this is made
much worse if there is dead time while they client app is processing.

In general, client apps should receive a signal in a non blocking way
and return a response as soon as possible.

To help encourage this behavior, the default timeout is 10 seconds.

This timeout period is configurable by the host app.

## Testing

Here is how I tested this out locally. I'm just including it here for completeness:

- Run `bundle exec rails console` in the root of the demux gem to get a console.
- Create Demux::App `app = Demux::App.create(name: "Test App", signal_url: "http://localhost:3000/signal/receive")`
- Create connection `app.connections.create(account_id: 9)`

- Run the test dummy app locally: https://github.com/lessonly/lessonly_apps_test_dummy after cloning it, run `bundle/setup` and then create a .env file with the following:

```
RACK_ENV=development
PORT=3000
LLY_SECRET=somesecrethere
TIMEOUT_DELAY=30
```

The TIMEOUT_DELAY is what will allow us to test the timeout.

- Start the test app `heroku local`
- Now, back in the Demux console you can trigger a signal `LessonSignal.new(1, account_id: 9).updated` where 1 is the ID of a lesson you create in your demux test DB and 9 an account_id for an connection/app you have also set up locally.

This should wait for 10 seconds before it ultimately times out. You can check the most recent transmission record to make sure it's a timeout: `Demux::Transmission.last`
