### PR TITLE
Add method for purging transmissions over a certain age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Make it easier to override the Demuxer](https://github.com/rreinhardt9/demux/pull/4/commits/970a0005125587368c837752820113a94b85292c)
 - [Add the ability to configure a timeout duration](https://github.com/rreinhardt9/demux/pull/9) for sending a signal and set it to 10 seconds by default
+- [Add method for purging old transmissions](https://github.com/lessonly/demux/pull/13) This can be called periodically in the method of your choosing to remove old transmissions.
 
 # 0.1.0.beta / 5-29-2020
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Demux.configure do |config|
 end
 ```
 
+#### Purging Old Signals
+
+Since we are creating new transmissions all the time, the demux_transmissions table has the potential to get very large. You will very likely want to set up a job to purge old transmissions periodically. For this you can use the `Demux::Transmission#purge` method and call it using the task scheduling method of your choosing. For example, you could set up a job that runs every night and purges transmissions older than a month using the following call:
+
+```Ruby
+Demux::Transmissions.purge(older_then: 1.month.ago)
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/app/models/demux/transmission.rb
+++ b/app/models/demux/transmission.rb
@@ -19,6 +19,18 @@ module Demux
       rescue ActiveRecord::RecordNotUnique
         # Unique index by status/uniqueness_hash
       end
+
+      # Purge old transmissions
+      #
+      # @param older_then [String, #to_s] updated_at date before which to
+      #   purge. It should be a valid datetime string or an
+      #   object that returns one when to_s is called on it.
+      #
+      # @return [self]
+
+      def purge(older_then:)
+        where("updated_at < ?", older_then).destroy_all
+      end
     end
 
     def transmit

--- a/test/fixtures/demux/transmissions.yml
+++ b/test/fixtures/demux/transmissions.yml
@@ -1,0 +1,7 @@
+slack:
+  app: :slack
+
+purgable_slack:
+  app: :slack
+  created_at: <%= 2.months.ago %>
+  updated_at: <%= 2.months.ago %>

--- a/test/models/demux/transmission_test.rb
+++ b/test/models/demux/transmission_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Demux
+  class TransmissionTest < ActiveSupport::TestCase
+    test "#purge removes transmissions older then the given date" do
+      slack_transmission = demux_transmissions(:slack)
+      purgable_transmission = demux_transmissions(:purgable_slack)
+
+      Demux::Transmission.purge(older_then: 1.month.ago)
+
+      assert Demux::Transmission.where(id: slack_transmission.id).exists?
+      refute Demux::Transmission.where(id: purgable_transmission.id).exists?
+    end
+  end
+end


### PR DESCRIPTION
Closes #11

Because we will be sending signals all the time, they could stack up
quickly and result in a huge table. Performance for signal sending could
start to suffer.

Based on the reasons outlined above, I think we should provide a way to
clean up transmission over a certain age.
