### PR TITLE
Refactor reference signal_attributes to not share instance variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Add method for purging old transmissions](https://github.com/lessonly/demux/pull/13) This can be called periodically in the method of your choosing to remove old transmissions.
 - [Add ability to pass context to signals and use an object not just an ID for the object](https://github.com/lessonly/demux/pull/15). Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 - [Add ability to pass extra data in token payload for Demux::Connection#entry_url](https://github.com/lessonly/demux/pull/18)
+- [Change how signal attributes are referenced in custom demuxer](https://github.com/lessonly/demux/pull/14) This will require you to update your custom demuxer if you have one.
 
 # 0.1.0.beta / 5-29-2020
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Lets say we want to create a demuxer that asynchronously resolve the signal and 
 class AsyncDemuxer < Demux::Demuxer
   def resolve
     # Job to resolve signal. In that job we call #resolve_now
-    DemuxResolverJob.perform(@signal_attributes)
+    DemuxResolverJob.perform(demuxer_arguments)
 
     self
   end
@@ -306,9 +306,9 @@ class AsyncDemuxer < Demux::Demuxer
 end
 
 class DemuxResolverJob
-  def perform(signal_attributes)
+  def perform(demuxer_arguments)
     # Here is an example of calling `resolve_now` in the job
-    AsyncDemuxer.new(signal_attributes).resolve_now
+    AsyncDemuxer.new(**demuxer_arguments).resolve_now
   end
 end
 

--- a/lib/demux/demuxer.rb
+++ b/lib/demux/demuxer.rb
@@ -9,8 +9,17 @@ module Demux
   # background queue and can supply their own demuxer with details on how that
   # should happen.
   class Demuxer
-    def initialize(signal_attributes)
-      @signal_attributes = signal_attributes
+    # Return the agruments that will be needed to re-initialize a custom
+    # demuxer. These might be used to pass to a job in which the custom demuxer
+    # would call resolve_now
+    #
+    # @returns [Hash] hash representing the signal_attributes for initializing
+    # the demuxer
+    attr_reader :demuxer_arguments
+
+    def initialize(**args)
+      @demuxer_arguments = args
+      @signal_attributes = SignalAttributes.new(**@demuxer_arguments)
       @account_id = @signal_attributes.account_id
       @signal_class = @signal_attributes.signal_class
     end

--- a/lib/demux/signal.rb
+++ b/lib/demux/signal.rb
@@ -50,13 +50,11 @@ module Demux
 
     def send(action, context: {})
       @demuxer.new(
-        SignalAttributes.new(
-          account_id: @account_id,
-          action: String(action),
-          object_id: @object_id,
-          context: @context.merge(context),
-          signal_class: self.class.name
-        )
+        account_id: @account_id,
+        action: String(action),
+        object_id: @object_id,
+        context: @context.merge(context),
+        signal_class: self.class.name
       ).resolve
 
       self


### PR DESCRIPTION
When subclasses access an instance variable from a parent, it makes
assumptions about that instance variable. This couples the two together
in a way that isn't clear to understand and can make change had.

This refactor adds a method that can be called instead of accessing the
instance variable.

Additionally, it's a little awkward to have to know about the
SignalAttributes object in the custom demuxer. This changes the demuxer
to initialize using keyword arguments instead of a SignalAttributes
object.
