### PR TITLE
Accept context and objects in signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Make it easier to override the Demuxer](https://github.com/rreinhardt9/demux/pull/4/commits/970a0005125587368c837752820113a94b85292c)
 - [Add the ability to configure a timeout duration](https://github.com/rreinhardt9/demux/pull/9) for sending a signal and set it to 10 seconds by default
 - [Add method for purging old transmissions](https://github.com/lessonly/demux/pull/13) This can be called periodically in the method of your choosing to remove old transmissions.
+- [Add ability to pass context to signals and use an object not just an ID for the object](https://github.com/lessonly/demux/pull/15). Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 
 # 0.1.0.beta / 5-29-2020
 

--- a/app/models/demux/transmission.rb
+++ b/app/models/demux/transmission.rb
@@ -76,7 +76,7 @@ module Demux
 
     def signal
       @signal ||= signal_class.constantize.new(
-        object_id, account_id: account_id
+        object_id, account_id: account_id, context: context
       )
     end
 

--- a/db/migrate/20200505201706_create_demux_transmissions.rb
+++ b/db/migrate/20200505201706_create_demux_transmissions.rb
@@ -10,6 +10,7 @@ class CreateDemuxTransmissions < ActiveRecord::Migration[5.2]
       t.string :response_code
       t.jsonb :response_headers
       t.text :response_body
+      t.jsonb :context
       t.jsonb :request_headers
       t.text :request_body
       t.string :request_url

--- a/lib/demux/signal.rb
+++ b/lib/demux/signal.rb
@@ -4,7 +4,7 @@ module Demux
   # All signals will inherit from Demux::Signal. A signal represent a message
   # to be demuxed and sent to apps.
   class Signal
-    attr_reader :account_id
+    attr_reader :account_id, :context
 
     class << self
       attr_reader :object_class, :signal_name
@@ -19,16 +19,25 @@ module Demux
       self.class.signal_name
     end
 
-    def initialize(object_id,
+    def initialize(object_or_id,
                    account_id:,
+                   context: {},
                    demuxer: Demux.config.default_demuxer)
-      @object_id = Integer(object_id)
+      if object_or_id.is_a?(Integer)
+        @object_id = object_or_id
+      else
+        @object = object_or_id
+        @object_id = object.try(:id)
+      end
       @account_id = account_id
+      @context = context.symbolize_keys
       @demuxer = demuxer
     end
 
     def object
-      @object ||= self.class.object_class.find(@object_id)
+      @object ||= if @object_id.present?
+                    self.class.object_class.find(@object_id)
+                  end
     end
 
     def payload_for(action)
@@ -39,12 +48,13 @@ module Demux
       end
     end
 
-    def send(action)
+    def send(action, context: {})
       @demuxer.new(
         SignalAttributes.new(
           account_id: @account_id,
           action: String(action),
           object_id: @object_id,
+          context: @context.merge(context),
           signal_class: self.class.name
         )
       ).resolve

--- a/lib/demux/signal_attributes.rb
+++ b/lib/demux/signal_attributes.rb
@@ -3,22 +3,24 @@
 module Demux
   # Attributes that are commonly used to identify a signal
   class SignalAttributes
-    attr_reader :account_id, :action, :object_id, :signal_class
+    attr_reader :account_id, :action, :context, :object_id, :signal_class
 
     class << self
       def from_object(object)
         new(
           account_id: object.account_id,
           action: object.action,
+          context: object.context,
           object_id: object.object_id,
           signal_class: object.signal_class
         )
       end
     end
 
-    def initialize(account_id:, action:, object_id:, signal_class:)
+    def initialize(account_id:, action:, context:, object_id:, signal_class:)
       @account_id = account_id
       @action = action
+      @context = Hash(context)
       @object_id = object_id
       @signal_class = String(signal_class)
     end
@@ -27,18 +29,14 @@ module Demux
       {
         account_id: @account_id,
         action: @action,
+        context: @context,
         object_id: @object_id,
         signal_class: @signal_class
       }
     end
 
     def hashed
-      Base64.strict_encode64({
-        account_id: account_id,
-        action: action,
-        object_id: object_id,
-        signal_class: signal_class
-      }.to_json)
+      Base64.strict_encode64(to_hash.to_json)
     end
   end
 end

--- a/test/dummy/app/signals/lesson_signal.rb
+++ b/test/dummy/app/signals/lesson_signal.rb
@@ -7,7 +7,7 @@ class LessonSignal < Demux::Signal
     {
       company_id: lesson.company_id,
       lesson: {
-        id: @object_id,
+        id: object.id,
         name: lesson.name,
         public: lesson.public
       }
@@ -18,29 +18,30 @@ class LessonSignal < Demux::Signal
     send :updated
   end
 
-  def destroyed(context = {})
-    # How do we handle cases where we need to eager create the payload
-    # Do we just send the ID of the object in a case like this
-    # Some thoughts are below
+  def destroyed_payload
+    {
+      company_id: account_id,
+      **context
+    }
+  end
 
-    # Just call the payload early and pass it into send
-    send :destroyed, payload: payload
-    # Indicate eager with boolean
-    send :destroyed, eager: true
-    # New method for sending in an eager way
-    send_now :destroyed
-    # Allow extra in the moment context to be added by the caller.
-    # We could have a base `destroyed_payload` method in here that is pretty
-    # sparse or empty and then the destroyer passes in context for the
-    # lesson that was destroyed.
-    # The concerning part here is that "what is sent" logic leaks out to the
-    # caller in this case and could be inconsistent.
-    send :destroyed, add_context: context
+  def destroyed
+    send :destroyed, context: destroyed_context
   end
 
   private
 
   def lesson
     object
+  end
+
+  def destroyed_context
+    {
+      lesson: {
+        id: lesson.id,
+        name: lesson.name,
+        public: lesson.public
+      }
+    }
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_201706) do
+ActiveRecord::Schema.define(version: 2020_07_21_203032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_201706) do
     t.string "response_code"
     t.jsonb "response_headers"
     t.text "response_body"
+    t.jsonb "context"
     t.jsonb "request_headers"
     t.text "request_body"
     t.string "request_url"


### PR DESCRIPTION
Resolves #5
Resolves #6

Some signals will have ephemeral data or be based on objects that cannot
be retrieved from the database by an ID.

See the issues for more context on the why, and the readme additions for more info on the how.


## Upgrade Notes

For any app that as already installed and run the migrations from Demux, you will need to craft a migration to add the context field to transmissions within your app. That migration would look something like:

```Ruby
class AddContextToDemuxTransmissions < ActiveRecord::Migration
  def change
    add_column :demux_transmissions, :context, :jsonb
  end
end
```
