### PR TITLE
Accept extra data to include in token when building entry_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Add the ability to configure a timeout duration](https://github.com/rreinhardt9/demux/pull/9) for sending a signal and set it to 10 seconds by default
 - [Add method for purging old transmissions](https://github.com/lessonly/demux/pull/13) This can be called periodically in the method of your choosing to remove old transmissions.
 - [Add ability to pass context to signals and use an object not just an ID for the object](https://github.com/lessonly/demux/pull/15). Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
+- [Add ability to pass extra data in token payload for Demux::Connection#entry_url](https://github.com/lessonly/demux/pull/18)
 
 # 0.1.0.beta / 5-29-2020
 

--- a/app/models/demux/connection.rb
+++ b/app/models/demux/connection.rb
@@ -24,10 +24,14 @@ module Demux
 
     # Return an entry url for this specific connection
     #
-    # @return [String] the entry url with account_id in signed token
+    # @param data [Hash] extra data to pass along when building the entry_url.
+    #   Whatever is passed in this hash will be included in addition to the
+    #   default `account_id` key.
+    #
+    # @return [String] the entry url with account ID and other data in token
 
-    def entry_url
-      app.signed_entry_url(data: { account_id: account_id })
+    def entry_url(data: {})
+      app.signed_entry_url(data: data.merge(account_id: account_id))
     end
   end
 end

--- a/test/models/demux/connection_test.rb
+++ b/test/models/demux/connection_test.rb
@@ -11,13 +11,32 @@ module Demux
       url = connection.entry_url
       token = url.match(/token=(?<token>.*)/)[:token]
       decoded_token = JWT.decode(
-        token, app.secret, true, { algorithm: "HS256" }
+        token, app.secret, true, algorithm: "HS256"
       )
 
       assert_equal(
         connection.account_id,
         decoded_token.first["data"]["account_id"]
       )
+    end
+
+    test "#entry_url accepts extra data to pass along in payload" do
+      connection = demux_connections(:acme_slack)
+      app = demux_apps(:slack)
+
+      url = connection.entry_url(data: { user_id: 42 })
+      token = url.match(/token=(?<token>.*)/)[:token]
+      decoded_token = JWT.decode(
+        token, app.secret, true, algorithm: "HS256"
+      )
+
+      decoded_data = decoded_token.first["data"]
+
+      assert_equal(
+        connection.account_id,
+        decoded_data["account_id"]
+      )
+      assert_equal 42, decoded_data["user_id"]
     end
   end
 end


### PR DESCRIPTION
Resolves #8

When building a signed entry url from a connection, it could be helpful
to pass additional data to be sent in the token. For example, maybe in
addition to an account_id you would want to pass the user_id of the user
that launched the app.

It's worth noting that you can already do this by using the
`signed_entry_url` method defined on an instance of an app and supply
any data you want there. This is specifically for cases where you want
the entry url from a connection (including the account_id automatically)
but would also like to pass additional data.
