### PR TITLE
Change signal attributes hashing algorithm to sha256

### DIFF
--- a/lib/demux/signal_attributes.rb
+++ b/lib/demux/signal_attributes.rb
@@ -35,8 +35,13 @@ module Demux
       }
     end
 
+    # Creates a unique hash of the signal attributes to uniquely identify this
+    # configuration by.
+    #
+    # @return [String] a sha256 hexidigest of attributes
+
     def hashed
-      Base64.strict_encode64(to_hash.to_json)
+      Digest::SHA256.hexdigest(to_hash.to_json)
     end
   end
 end


### PR DESCRIPTION
Resolves #16

The purpose of hashing the signal attributes is just to compare one set
with another to see if they are equivalent. Using sha256 better
accomplishes this goal while having the benefit of also being fixed
length.
