### PR TITLE
Rename transmission timeout status to request_timeout

### DIFF
--- a/app/models/demux/transmission.rb
+++ b/app/models/demux/transmission.rb
@@ -7,7 +7,7 @@ module Demux
 
     before_save :update_uniqueness_hash
 
-    enum status: %i[queued sending success failure timeout]
+    enum status: %i[queued sending success failure request_timeout]
 
     class << self
       def for_app(app_relation)

--- a/lib/demux/transmitter.rb
+++ b/lib/demux/transmitter.rb
@@ -59,7 +59,7 @@ module Demux
 
       self
     rescue Net::ReadTimeout, Net::OpenTimeout, Net::WriteTimeout
-      @status = :timeout
+      @status = :request_timeout
     end
 
     def request_options

--- a/test/integration/demux/signals_test.rb
+++ b/test/integration/demux/signals_test.rb
@@ -96,10 +96,10 @@ module Demux
       assert_requested(reporting_post)
 
       slack_transmission = slack.transmissions.last
-      assert_equal slack_transmission.status, "timeout"
+      assert_equal slack_transmission.status, "request_timeout"
 
       reporting_transmission = reporting.transmissions.last
-      assert_equal reporting_transmission.status, "timeout"
+      assert_equal reporting_transmission.status, "request_timeout"
     end
   end
 end


### PR DESCRIPTION
Fixes #17

Renaming `timeout` key in the enum because it creates a class method by
the same name that overrides a ruby reserved class method name and
causes a warning to be emitted whenever the code is loaded.
