### PR TITLE
Add support for connecting to multiple account types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Add ability to pass context to signals and use an object not just an ID for the object](https://github.com/lessonly/demux/pull/15). Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 - [Add ability to pass extra data in token payload for Demux::Connection#entry_url](https://github.com/lessonly/demux/pull/18)
 - [Change how signal attributes are referenced in custom demuxer](https://github.com/lessonly/demux/pull/14) This will require you to update your custom demuxer if you have one.
+- [Add support for multiple accounts](https://github.com/lessonly/demux/pull/24) Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 
 # 0.1.0.beta / 5-29-2020
 

--- a/app/models/demux/connection.rb
+++ b/app/models/demux/connection.rb
@@ -1,16 +1,32 @@
 # frozen_string_literal: true
 
 module Demux
+  # Connection between an account and a Demux::App
   class Connection < ApplicationRecord
     belongs_to :app
 
     class << self
-      def listening_for(signal_name:, account_id:)
-        where(account_id: account_id)
+      # Retrieve connections listening for a specific signal and account
+      #
+      # @param signal_name [String] name of the signal
+      # @param account_id [Integer] ID of the account
+      # @param account_type [String] Type of account for the supplied ID
+      #
+      # @return [ActiveRecord::Relation<Demux::Connection>]
+      def listening_for(signal_name:, account_id:, account_type:)
+        where(
+          account_id: account_id,
+          account_type: account_type
+        )
           .signal(signal_name)
           .or(wildcard_signal)
       end
 
+      # Find connections listening for a specific signal name
+      #
+      # @param signal [String] name of the signal
+      #
+      # @return [ActiveRecord::Relation<Demux::Connection>]
       def signal(signal)
         where("demux_connections.signals @> ?", "{#{signal}}")
       end
@@ -26,12 +42,16 @@ module Demux
     #
     # @param data [Hash] extra data to pass along when building the entry_url.
     #   Whatever is passed in this hash will be included in addition to the
-    #   default `account_id` key.
+    #   default `account_id` and `account_type` keys.
     #
-    # @return [String] the entry url with account ID and other data in token
-
+    # @return [String] the entry url with account ID, account type, and other
+    #   data in token
     def entry_url(data: {})
-      app.signed_entry_url(data: data.merge(account_id: account_id))
+      app.signed_entry_url(
+        data: data.merge(
+          account_id: account_id, account_type: account_type
+        )
+      )
     end
   end
 end

--- a/db/migrate/20200423143645_create_demux_apps.rb
+++ b/db/migrate/20200423143645_create_demux_apps.rb
@@ -7,6 +7,7 @@ class CreateDemuxApps < ActiveRecord::Migration[5.1]
       t.string :entry_url
       t.string :signal_url
       t.text :signals, array:true, default: []
+      t.text :account_types, array:true, default: []
 
       t.timestamps
     end

--- a/db/migrate/20200423144102_create_demux_connections.rb
+++ b/db/migrate/20200423144102_create_demux_connections.rb
@@ -2,13 +2,14 @@ class CreateDemuxConnections < ActiveRecord::Migration[5.1]
   def change
     create_table :demux_connections do |t|
       t.integer :account_id
+      t.string :account_type
       t.integer :app_id
       t.text :signals, array:true, default: []
 
       t.timestamps
     end
     add_index :demux_connections, :signals, using: "gin"
-    add_index :demux_connections, :account_id
+    add_index :demux_connections, [:account_id, :account_type]
     add_index :demux_connections, :app_id
   end
 end

--- a/db/migrate/20200505201706_create_demux_transmissions.rb
+++ b/db/migrate/20200505201706_create_demux_transmissions.rb
@@ -6,6 +6,7 @@ class CreateDemuxTransmissions < ActiveRecord::Migration[5.2]
       t.integer :object_id
       t.integer :app_id
       t.integer :account_id
+      t.string :account_type
       t.integer :status, default: 0
       t.string :response_code
       t.jsonb :response_headers

--- a/lib/demux/demuxer.rb
+++ b/lib/demux/demuxer.rb
@@ -21,6 +21,7 @@ module Demux
       @demuxer_arguments = args
       @signal_attributes = SignalAttributes.new(**@demuxer_arguments)
       @account_id = @signal_attributes.account_id
+      @account_type = @signal_attributes.account_type
       @signal_class = @signal_attributes.signal_class
     end
 
@@ -83,7 +84,8 @@ module Demux
     def listening_apps
       Demux::App.listening_for(
         signal_name: @signal_class.constantize.signal_name,
-        account_id: @account_id
+        account_id: @account_id,
+        account_type: @account_type
       )
     end
   end

--- a/lib/demux/signal.rb
+++ b/lib/demux/signal.rb
@@ -7,9 +7,10 @@ module Demux
     attr_reader :account_id, :context
 
     class << self
-      attr_reader :object_class, :signal_name
+      attr_reader :account_type, :object_class, :signal_name
 
       def attributes(attr)
+        @account_type = attr.fetch(:account_type)
         @object_class = attr.fetch(:object_class)
         @signal_name = attr.fetch(:signal_name)
       end
@@ -17,6 +18,13 @@ module Demux
 
     def signal_name
       self.class.signal_name
+    end
+
+    # Type of account for the give signal
+    #
+    # @return [String] account type
+    def account_type
+      self.class.account_type
     end
 
     def initialize(object_or_id,
@@ -29,6 +37,7 @@ module Demux
         @object = object_or_id
         @object_id = object.try(:id)
       end
+
       @account_id = account_id
       @context = context.symbolize_keys
       @demuxer = demuxer
@@ -51,6 +60,7 @@ module Demux
     def send(action, context: {})
       @demuxer.new(
         account_id: @account_id,
+        account_type: account_type,
         action: String(action),
         object_id: @object_id,
         context: @context.merge(context),

--- a/lib/demux/signal_attributes.rb
+++ b/lib/demux/signal_attributes.rb
@@ -3,12 +3,18 @@
 module Demux
   # Attributes that are commonly used to identify a signal
   class SignalAttributes
-    attr_reader :account_id, :action, :context, :object_id, :signal_class
+    attr_reader :account_id,
+                :account_type,
+                :action,
+                :context,
+                :object_id,
+                :signal_class
 
     class << self
       def from_object(object)
         new(
           account_id: object.account_id,
+          account_type: object.account_type,
           action: object.action,
           context: object.context,
           object_id: object.object_id,
@@ -17,8 +23,9 @@ module Demux
       end
     end
 
-    def initialize(account_id:, action:, context:, object_id:, signal_class:)
+    def initialize(account_id:, account_type:, action:, context:, object_id:, signal_class:)
       @account_id = account_id
+      @account_type = account_type
       @action = action
       @context = Hash(context)
       @object_id = object_id
@@ -28,6 +35,7 @@ module Demux
     def to_hash
       {
         account_id: @account_id,
+        account_type: @account_type,
         action: @action,
         context: @context,
         object_id: @object_id,

--- a/test/dummy/app/signals/lesson_signal.rb
+++ b/test/dummy/app/signals/lesson_signal.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LessonSignal < Demux::Signal
-  attributes object_class: Lesson, signal_name: "lesson"
+  attributes object_class: Lesson, signal_name: "lesson", account_type: :account
 
   def payload
     {

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_203032) do
+ActiveRecord::Schema.define(version: 2020_05_05_201706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_203032) do
     t.string "entry_url"
     t.string "signal_url"
     t.text "signals", default: [], array: true
+    t.text "account_types", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["secret"], name: "index_demux_apps_on_secret", unique: true
@@ -30,11 +31,12 @@ ActiveRecord::Schema.define(version: 2020_07_21_203032) do
 
   create_table "demux_connections", force: :cascade do |t|
     t.integer "account_id"
+    t.string "account_type"
     t.integer "app_id"
     t.text "signals", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["account_id"], name: "index_demux_connections_on_account_id"
+    t.index ["account_id", "account_type"], name: "index_demux_connections_on_account_id_and_account_type"
     t.index ["app_id"], name: "index_demux_connections_on_app_id"
     t.index ["signals"], name: "index_demux_connections_on_signals", using: :gin
   end
@@ -45,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_203032) do
     t.integer "object_id"
     t.integer "app_id"
     t.integer "account_id"
+    t.string "account_type"
     t.integer "status", default: 0
     t.string "response_code"
     t.jsonb "response_headers"

--- a/test/fixtures/demux/apps.yml
+++ b/test/fixtures/demux/apps.yml
@@ -6,6 +6,7 @@ slack:
   secret: tokenslack
   entry_url: http://slack.example.com/connection/new
   signal_url: https://slack.example.com/hooks
+  account_types: ["account"]
 
 reporting:
   name: Reporting Engine
@@ -13,3 +14,12 @@ reporting:
   secret: tokenreporting
   entry_url: http://reportz.biz/setup
   signal_url: https://reportz.biz/webhooks
+  account_types: ["account"]
+
+chatbot:
+  name: Chatbot
+  description: Chat with your team
+  secret: tokenchat
+  entry_url: https://chatbot.co/setup
+  signal_url: https://chatbot.co/signal_receive
+  account_types: ["user"]

--- a/test/fixtures/demux/connections.yml
+++ b/test/fixtures/demux/connections.yml
@@ -2,10 +2,18 @@
 
 acme_slack:
   account_id: 1
+  account_type: account
   signals: ["lesson"]
   app: slack
 
 acme_reporting:
   account_id: 1
+  account_type: account
   signals: ["lesson"]
   app: reporting
+
+acme_chatbot:
+  account_id: 1
+  account_type: user
+  signals: ["user_notification"]
+  app: chatbot

--- a/test/integration/demux/signals_test.rb
+++ b/test/integration/demux/signals_test.rb
@@ -27,7 +27,7 @@ module Demux
         )
       reporting_post = stub_request(:post, demux_apps(:reporting).signal_url)
 
-      LessonSignal.new(lesson.id, account_id: lesson.company_id).updated
+      LessonSignal.new(lesson.id, account_id: 1).updated
 
       assert_requested(slack_post)
       assert_requested(reporting_post)

--- a/test/models/demux/app_test.rb
+++ b/test/models/demux/app_test.rb
@@ -16,5 +16,17 @@ module Demux
       assert_equal(9, decoded_token.first["data"]["account_id"])
       assert_match(%r{.*/connection/new\?token=.*}, url)
     end
+
+    test "#account_type? is true for matching account types" do
+      app = demux_apps(:slack)
+
+      assert app.account_type?(:account)
+    end
+
+    test "#account_type? is false for missing account types" do
+      app = demux_apps(:slack)
+
+      refute app.account_type?("user")
+    end
   end
 end

--- a/test/models/demux/connection_test.rb
+++ b/test/models/demux/connection_test.rb
@@ -4,6 +4,30 @@ require "test_helper"
 
 module Demux
   class ConnectionTest < ActiveSupport::TestCase
+    test "::listening_for returns connection based on account and signal" do
+      result = Connection.listening_for(
+        signal_name: "lesson",
+        account_id: demux_connections(:acme_slack).account_id,
+        account_type: "account"
+      )
+
+      assert result.include?(demux_connections(:acme_slack))
+    end
+
+    test "::listening_for does not return connection with a different account type" do
+      result = Connection.listening_for(
+        signal_name: "lesson",
+        account_id: demux_connections(:acme_slack).account_id,
+        account_type: "user" # acme_slack is listening for account not user
+      )
+
+      refute(
+        result.include?(demux_connections(:acme_slack)),
+        "acme_slack should not be in the result because it's listening for"\
+        "account and not user"
+      )
+    end
+
     test "#entry_url requests a app entry url with account_id as payload" do
       connection = demux_connections(:acme_slack)
       app = demux_apps(:slack)
@@ -17,6 +41,10 @@ module Demux
       assert_equal(
         connection.account_id,
         decoded_token.first["data"]["account_id"]
+      )
+      assert_equal(
+        connection.account_type,
+        decoded_token.first["data"]["account_type"]
       )
     end
 


### PR DESCRIPTION
Resolves #22 

Add the ability for signals to listen for different account types within the same app.

We'll explore adding inheritable attributes in signals as mentioned in the issue in another PR.

## Migrations Notes

When upgrading you'll need to run these migrations in your application.
``` ruby
class AddAccountTypesToDemuxApps < ActiveRecord::Migration
  def change
    add_column :demux_apps, :account_types, array: true, default: []
  end
end

class AddAccountTypeToDemuxConnections < ActiveRecord::Migration
  def change
    add_column :demux_connections, :account_type, :string
  end
end

class AlterAccountIndexOnDemuxConnections < ActiveRecord::Migration
  def change
    remove_index :demux_connections, :account_id
    add_index :demux_connections, [:account_id, :account_type]
  end
end

class AddAccountTypeToDemuxTranmissions < ActiveRecord::Migration
  def change
    add_column :demux_transmissions, :account_type, :string
  end
end
```