### PR TITLE
Add configuration column to demux apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Change how signal attributes are referenced in custom demuxer](https://github.com/lessonly/demux/pull/14) This will require you to update your custom demuxer if you have one.
 - [Add support for multiple accounts](https://github.com/lessonly/demux/pull/24) Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 - [Change parameter accepted by #purge](https://github.com/lessonly/demux/pull/25) from 'older_then' to 'older_than'. (breaking change) Thanks @SherSpock !
+- [Add configuration column to Demux Apps](https://github.com/lessonly/demux/pull/29) Important! This requires you to create your own migration to upgrade if you've run the migrations from Demux before.
 
 # 0.1.0.beta / 5-29-2020
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ Resulting in a payload like:
 }
 ```
 
+### Apps
+
+#### Configuring apps
+
+`Demux::App` records include a column useful for parent app metadata called `configuration`. This is a Rails jsonb column.
+
+```ruby
+app = Demux::App.find(1)
+app.configuration['publicly_available'] = true
+app.save
+
+app.configuration['publicly_available']
+=> true
+```
+
 ### Signals
 
 Signals are messages that are sent to apps that are connected to an account in response to events that happen in that account. Demux acts like a switchboard making sure that any apps connected to the account where the event happened and that are listening for that signal will receive it. When a signal is called, Demux will resolve that signal so that it is sent to any connections that are listening for that signal on that account ID and type.

--- a/db/migrate/20200423143645_create_demux_apps.rb
+++ b/db/migrate/20200423143645_create_demux_apps.rb
@@ -8,10 +8,12 @@ class CreateDemuxApps < ActiveRecord::Migration[5.1]
       t.string :signal_url
       t.text :signals, array:true, default: []
       t.text :account_types, array:true, default: []
+      t.jsonb :configuration, default: {}
 
       t.timestamps
     end
     add_index :demux_apps, :signals, using: "gin"
+    add_index :demux_apps, :configuration, using: "gin"
     add_index :demux_apps, :secret, unique: true
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -23,8 +23,10 @@ ActiveRecord::Schema.define(version: 2020_05_05_201706) do
     t.string "signal_url"
     t.text "signals", default: [], array: true
     t.text "account_types", default: [], array: true
+    t.jsonb "configuration", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["configuration"], name: "index_demux_apps_on_configuration", using: :gin
     t.index ["secret"], name: "index_demux_apps_on_secret", unique: true
     t.index ["signals"], name: "index_demux_apps_on_signals", using: :gin
   end


### PR DESCRIPTION
resolves: #28

`Demux::App` records include a column useful for parent app metadata called `configuration`. This is a Rails jsonb column.