### PR TITLE
Add RSA access keys to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,42 @@ app.configuration['publicly_available']
 => true
 ```
 
+#### App Access Keys
+
+When a Demux::App communicates with the parent application, App access keys allow us to verify the identity of that app.
+
+To generate a new key for your app:
+
+```ruby
+app = Demux::App.find(1)
+key = app.generate_access_key
+```
+
+Calling this method will generate a new access_key associated to your app. An app can have multiple keys at the same to to allow for key rotation (updating the private key in the app to the new value before destroying the old private key).
+
+Demux does not store the private key, this will only be available on the AccessKey record when it's first created. In the example above, we could access the private key from our new access_key in this way:
+
+```ruby
+key.private_key
+=> -----BEGIN RSA PRIVATE KEY-----
+...
+```
+This is our only chance to view the private key; only the public_key will be persisted. In your parent application, you will need to provide a way to return this private key to the creator.
+
+The public key and a "fingerprint" will be persisted:
+
+```ruby
+key.public_key
+=> -----BEGIN PUBLIC KEY-----
+key.fingerprint
+=> "nTnIQ2ru5HdYKBluJty9aBRrn+474oh8lHG2vMJl8Lw="
+```
+
+This fingerprint can be used to identify an AccessKey later from a given private key. You can use the following to generate a fingerprint from a private key PEM file:
+```
+$ openssl rsa -in PATH_TO_PEM_FILE -pubout -outform DER | openssl sha256 -binary | openssl base64
+```
+
 ### Signals
 
 Signals are messages that are sent to apps that are connected to an account in response to events that happen in that account. Demux acts like a switchboard making sure that any apps connected to the account where the event happened and that are listening for that signal will receive it. When a signal is called, Demux will resolve that signal so that it is sent to any connections that are listening for that signal on that account ID and type.

--- a/app/models/demux/access_key.rb
+++ b/app/models/demux/access_key.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Demux
+  # Demux::AccessKey represents an RSA key pair associated with an app. The
+  # apps may use this key to secure communications with the parent app.
+  #
+  # AccessKey only stores the 'public' key for verifying communication from
+  # the associated app. The 'private' key will not be stored and should be
+  # provided to the app.
+  #
+  # The fingerprint on an AccessKey is a hashed version of the 'public' key
+  # that can be used to identify a given key based on it's PEM file.
+  class AccessKey < ApplicationRecord
+    # The private key for a newly generated AccessKey.
+    # This attribute is not persisted to the database and should be provided
+    # to the external app for use.
+    # @return [String] RSA private key in PEM format
+    attr_accessor :private_key
+
+    belongs_to :app
+
+    validates :fingerprint, :public_key, presence: true
+
+    class << self
+      # Create a new access key for an app.
+      # This method is intended to be used through an app record.
+      # @see Demux::App#generate_access_key
+      #
+      # @example
+      #   app = Demux::App.find(1)
+      #   access_key = app.generate_access_key
+      #
+      #   access_key.public_key => # public key PEM
+      #   access_key.private_key => # private key PEM
+      #
+      # @returns [Demux::AccessKey] newly created access key
+      def generate_new
+        key = OpenSSL::PKey::RSA.new 2048
+
+        create(
+          public_key: key.public_key.to_pem,
+          fingerprint: "SHA256:#{key_fingerprint(key.public_key.to_der)}"
+        ).tap do |new_key|
+          new_key.private_key = key.to_pem
+        end
+      end
+
+      private
+
+      # Generate a fingerprint given the DER representation of a public key
+      #
+      # @param key_der [String] DER representation of a public key
+      #
+      # @return [String] a unique hashed representation of this public key
+      def key_fingerprint(key_der)
+        Base64.strict_encode64(OpenSSL::Digest.new("SHA256").digest(key_der))
+      end
+    end
+  end
+end

--- a/app/models/demux/app.rb
+++ b/app/models/demux/app.rb
@@ -10,6 +10,7 @@ module Demux
 
     has_many :connections
     has_many :transmissions
+    has_many :access_keys
     has_secure_token :secret
 
     validates :entry_url, :signal_url, format: { with: URL_REGEX }
@@ -75,10 +76,17 @@ module Demux
     # @param exp [Integer] expiration of token in seconds since the epoch
     #
     # @return [String] the entry url with signed token appended
-
     def signed_entry_url(data: {}, exp: 1.minute.from_now.to_i)
       token = JWT.encode({ data: data, exp: exp }, secret, "HS256")
       "#{entry_url}?token=#{token}"
+    end
+
+    # Create a new access key for this app
+    # @see Demux::AccessKey#generate_new
+    #
+    # @return [Demux::AccessKey] the newly generated access key
+    def generate_access_key
+      access_keys.generate_new
     end
   end
 end

--- a/db/migrate/20210105192025_create_demux_access_keys.rb
+++ b/db/migrate/20210105192025_create_demux_access_keys.rb
@@ -1,0 +1,13 @@
+class CreateDemuxAccessKeys < ActiveRecord::Migration[5.2]
+  def change
+    create_table :demux_access_keys do |t|
+      t.text :public_key, null: false
+      t.integer :app_id, null: false
+      t.string :fingerprint, null: false
+
+      t.timestamps
+    end
+
+    add_index :demux_access_keys, :app_id
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_201706) do
+ActiveRecord::Schema.define(version: 2021_01_05_192025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "demux_access_keys", force: :cascade do |t|
+    t.text "public_key", null: false
+    t.integer "app_id", null: false
+    t.string "fingerprint", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_id"], name: "index_demux_access_keys_on_app_id"
+  end
 
   create_table "demux_apps", force: :cascade do |t|
     t.string "name"

--- a/test/models/demux/app_test.rb
+++ b/test/models/demux/app_test.rb
@@ -28,5 +28,15 @@ module Demux
 
       refute app.account_type?("user")
     end
+
+    test "generating a new access key" do
+      app = demux_apps(:slack)
+      key = app.generate_access_key
+
+      assert_match(/BEGIN PUBLIC KEY/, key.public_key)
+      assert_match(/BEGIN RSA PRIVATE KEY/, key.private_key)
+      assert_match(/SHA256:/, key.fingerprint)
+      assert_equal key.app_id, app.id
+    end
   end
 end


### PR DESCRIPTION
## Why?

Apps need a way to identify themselves to the parent app while performing administrative tasks, such as retrieving tokens for their connections, or creating/destroying connections, or managing attributes of themself.

## What?
Demux access keys will be used by parent apps to authorize an app wishing to perform administrative tasks. The app will use the provided private key to sign messages that are sent to the parent app. The parent app will then make use of the public key to authorize the request.

This PR simple creates the keys and associates them to an app. At this time, the thinking is that all the work making use of these keys for authorization will actually take place inside the parent app, most likely as the part of an API framework.

## Testing Notes

You can see the in-code documentation example (reprinted below) for the expected behavior:

To generate a new key for your app:

```ruby
app = Demux::App.find(1)
key = app.generate_access_key
```

Calling this method will generate a new access_key associated to your app. An app can have multiple keys at the same to to allow for key rotation (updating the private key in the app to the new value before destroying the old private key).

Demux does not store the private key, this will only be available on the AccessKey record when it's first created. In the example above, we could access the private key from our new access_key in this way:

```ruby
key.private_key
=> -----BEGIN RSA PRIVATE KEY-----
...
```
This is our only chance to view the private key; only the public_key will be persisted. In your parent application, you will need to provide a way to return this private key to the creator.

The public key and a "fingerprint" will be persisted:

```ruby
key.public_key
=> -----BEGIN PUBLIC KEY-----
key.fingerprint
=> "nTnIQ2ru5HdYKBluJty9aBRrn+474oh8lHG2vMJl8Lw="
```

This fingerprint can be used to identify an AccessKey later from a given private key. You can use the following to generate a fingerprint from a private key PEM file:
```
$ openssl rsa -in PATH_TO_PEM_FILE -pubout -outform DER | openssl sha256 -binary | openssl base64
```
