### PR TITLE
Add indicator to demux apps

### DIFF
--- a/app/models/demux/app.rb
+++ b/app/models/demux/app.rb
@@ -16,6 +16,7 @@ module Demux
     validates :entry_url, :signal_url, format: { with: URL_REGEX }
 
     validates :name, presence: true
+    validates :indicator, uniqueness: true, allow_blank: true
 
     class << self
       def listening_for(signal_name:, account_id:, account_type:)

--- a/app/models/demux/connection.rb
+++ b/app/models/demux/connection.rb
@@ -31,6 +31,19 @@ module Demux
         where("demux_connections.signals @> ?", "{#{signal}}")
       end
 
+      # Find connections that belong to an app with a specific indicator
+      #
+      # @param indicator [String] name of the indicator
+      #
+      # @return [ActiveRecord::Relation<Demux::Connection>]
+      def find_by_app_indicator(indicator:, account_id:, account_type:)
+        where(
+          app: Demux::App.where(indicator: indicator),
+          account_id: account_id,
+          account_type: account_type
+        )
+      end
+
       private
 
       def wildcard_signal

--- a/app/models/demux/connection.rb
+++ b/app/models/demux/connection.rb
@@ -37,7 +37,7 @@ module Demux
       #
       # @return [ActiveRecord::Relation<Demux::Connection>]
       def find_by_app_indicator(indicator:, account_id:, account_type:)
-        where(
+        find_by(
           app: Demux::App.where(indicator: indicator),
           account_id: account_id,
           account_type: account_type

--- a/db/migrate/20211207035653_add_indicator_to_demux_apps.rb
+++ b/db/migrate/20211207035653_add_indicator_to_demux_apps.rb
@@ -1,0 +1,5 @@
+class AddIndicatorToDemuxApps < ActiveRecord::Migration[5.2]
+  def change
+    add_column :demux_apps, :indicator, :text
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_192025) do
+ActiveRecord::Schema.define(version: 2021_12_07_035653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_192025) do
     t.jsonb "configuration", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "indicator"
     t.index ["configuration"], name: "index_demux_apps_on_configuration", using: :gin
     t.index ["secret"], name: "index_demux_apps_on_secret", unique: true
     t.index ["signals"], name: "index_demux_apps_on_signals", using: :gin

--- a/test/fixtures/demux/apps.yml
+++ b/test/fixtures/demux/apps.yml
@@ -23,3 +23,9 @@ chatbot:
   entry_url: https://chatbot.co/setup
   signal_url: https://chatbot.co/signal_receive
   account_types: ["user"]
+
+indicatio:
+  name: Indicat.io
+  description: Indicate your world
+  account_types: ["company"]
+  indicator: indicatio

--- a/test/fixtures/demux/connections.yml
+++ b/test/fixtures/demux/connections.yml
@@ -17,3 +17,8 @@ acme_chatbot:
   account_type: user
   signals: ["user_notification"]
   app: chatbot
+
+acme_indicatio:
+  account_id: 1
+  account_type: company
+  app: indicatio

--- a/test/models/demux/connection_test.rb
+++ b/test/models/demux/connection_test.rb
@@ -28,6 +28,16 @@ module Demux
       )
     end
 
+    test "::find_by_app_indicator returns connection based on account and indicator" do
+      result = Connection.find_by_app_indicator(
+        indicator: "indicatio",
+        account_id: demux_connections(:acme_indicatio).account_id,
+        account_type: "company"
+      )
+
+      assert_equal demux_connections(:acme_indicatio), result
+    end
+
     test "#entry_url requests a app entry url with account_id as payload" do
       connection = demux_connections(:acme_slack)
       app = demux_apps(:slack)


### PR DESCRIPTION
## Why? What?

Resolves [[sc-79145]](https://app.shortcut.com/lessonly/story/79145)

We are adding a column on `demux_apps` called `indicator`, which will allow apps using this gem to have a (well...) _indicator_ of what app this is.

For example, let's say Lessonly has an integration that is associated with Demux App X. There is a button that is shown in our application if a company has enabled Demux App X, but... how do we know which demux app record we should be looking for connections on? When configured, this new attribute will allow us to say "Okay look for connection records between Company Y and demux apps where `demux_app.indicator == "app_x"`, and then we'll know whether to show this button!

## Testing Notes

This can be tested locally in a database that uses this gem.

- [ ] The migration can be pulled from this gem by using `rails demux:install:migrations`. Does running `db:migrate` create a new `indicator` column on existing demux apps?
- [ ] Can the value of this new attribute be updated to a string value?
- [ ] Does validation fail if a demux app is updated with an indicator value that another record already has? 

[Here's a Loom](https://www.loom.com/share/c0b97497d18340cca89c872700a0e316) that shows the result of this testing!